### PR TITLE
Typo - 'Constainer'

### DIFF
--- a/src/util/overlay-trigger/index.js
+++ b/src/util/overlay-trigger/index.js
@@ -318,7 +318,7 @@ export default class OverlayTrigger extends Component {
 
     return (
       <Overlay
-        constainer={this.getOverlayContainer}
+        container={this.getOverlayContainer}
         onHide={this.handleRootClose}
         placement={position}
         rootClose={closeOnClickOutside}


### PR DESCRIPTION
Seems to be breaking predictable overlay behavior, especially when your target or container are not the body elements of the page.